### PR TITLE
Editorial: Markup/down fixes for proper Bikeshed algorithms

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -287,7 +287,7 @@ A [=lock request=] |request| is said to be <dfn>grantable</dfn> if the following
 ## Agent Integration ## {#agent-integration}
 <!-- ====================================================================== -->
 
-<div class=algorithm>
+<div algorithm="agent termination">
 When an [=/agent=] terminates, [=enqueue the following steps=] on the [=lock task queue=]:
 
 <aside class=issue>
@@ -572,7 +572,7 @@ The <dfn attribute for=Lock>mode</dfn> getter's steps are to return the associat
 ## Request a lock ## {#algorithm-request-lock}
 <!-- ====================================================================== -->
 
-<div class=algorithm>
+<div algorithm>
 To <dfn>request a lock</dfn> with |promise|, |agent|, |clientId|, |origin|, |callback|, |name|, |mode|, |ifAvailable| and |steal|:
 
 1. Let |request| be a new [=lock request=] (|agent|, |clientId|, |origin|, |name|, |mode|, |promise|).
@@ -601,7 +601,7 @@ To <dfn>request a lock</dfn> with |promise|, |agent|, |clientId|, |origin|, |cal
 ## Release a lock ## {#algorithm-release-lock}
 <!-- ====================================================================== -->
 
-<div class=algorithm>
+<div algorithm>
 To <dfn>release the lock</dfn> |lock|:
 
 1. [=Assert=]: these steps are running on the [=lock task queue=].
@@ -618,12 +618,12 @@ To <dfn>release the lock</dfn> |lock|:
 ## Abort a request ## {#algorithm-abort-request}
 <!-- ====================================================================== -->
 
-<div class=algorithm>
+<div algorithm>
 To <dfn>abort the request</dfn> |request|:
 
 1. [=Assert=]: these steps are running on the [=lock task queue=].
 1. Let |origin| be |request|'s [=lock request/origin=].
-1. Let |name| be |lock|'s [=resource name=].
+1. Let |name| be |request|'s [=lock request/name=].
 1. Let |queueMap| be |origin|'s [=lock request queue map=].
 1. Let |queue| be |queueMap|[|name|].
 1. [=list/Remove=] |request| from |queue|.
@@ -635,7 +635,7 @@ To <dfn>abort the request</dfn> |request|:
 ## Process a lock request queue for a given resource name ## {#algorithm-process-request}
 <!-- ====================================================================== -->
 
-<div class=algorithm>
+<div algorithm>
 To <dfn>process the lock request queue</dfn> |queue|:
 
 1. [=Assert=]: these steps are running on the [=lock task queue=].
@@ -660,12 +660,12 @@ To <dfn>process the lock request queue</dfn> |queue|:
 ## Snapshot the lock state ## {#algorithm-snapshot-state}
 <!-- ====================================================================== -->
 
-<div class=algorithm>
+<div algorithm>
 To <dfn>snapshot the lock state</dfn> for |origin| with |promise|:
 
 1. [=Assert=]: these steps are running on the [=lock task queue=].
 1. Let |pending| be a new [=list=].
-1. [=map/For each=] |name| &rarr; |queue| of |origin|'s [=lock request queue map=]:
+1. [=map/For each=] |queue| of |origin|'s [=lock request queue map=]'s [=map/values=]:
     1. [=list/For each=] |request| of |queue|:
         1. [=list/Append=] «[ "name" → |request|'s [=lock request/name=], "mode" → |request|'s [=lock request/mode=], "clientId" → |request|'s [=lock request/clientId=] ]» to |pending|.
 1. Let |held| be a new [=list=].


### PR DESCRIPTION
Minor changes:

* Use Bikeshed's algorithm more correctly
* Fix var issues that turned up: 
   * An unused var when iterating a map's values
   * An incorrect type reference in an algorithm (queues have requests, not locks)
