### PR TITLE
Remove abort steps when lock is granted

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -668,7 +668,8 @@ To <dfn>process the lock request queue</dfn> |queue|:
         1. [=set/Append=] |lock| to |origin|'s [=held lock set=].
         1. [=Enqueue the following steps=] on |callback|'s [=relevant settings object=]'s [=responsible event loop=]:
             1. If |signal| is present, then run these steps:
-                1. If |signal|'s [=AbortSignal/aborted flag=] is set, then return.
+                1. If |signal|'s [=AbortSignal/aborted flag=] is set, then [=enqueue the following step=] to the [=lock task queue=]:
+                    1. [=Release the lock=] |lock|.
                 1. [=AbortSignal/Remove=] the algorithm [=signal to abort the request=] |request| from |signal|.
             1. Let |r| be the result of [=invoking=] |callback| with a new {{Lock}} object associated with |lock| as the only argument.
             1. [=/Resolve=] |waiting| with |r|.

--- a/index.bs
+++ b/index.bs
@@ -257,7 +257,7 @@ A <dfn>lock request</dfn> represents a pending request for a [=lock-concept|lock
 
 <div dfn-for="lock request">
 
-A [=lock request=] is a [=/struct=] with [=struct/items=] <dfn>agent</dfn>, <dfn>clientId</dfn>, <dfn>origin</dfn>, <dfn>name</dfn>, <dfn>mode</dfn>, <dfn>callback</dfn>, and <dfn>promise</dfn>.
+A [=lock request=] is a [=/struct=] with [=struct/items=] <dfn>agent</dfn>, <dfn>clientId</dfn>, <dfn>origin</dfn>, <dfn>name</dfn>, <dfn>mode</dfn>, <dfn>callback</dfn>, <dfn>promise</dfn>, and <dfn>signal</dfn>.
 
 </div>
 
@@ -494,10 +494,7 @@ The <dfn method for=LockManager>request(|name|, |callback|)</dfn> and
 1. If |options|' `signal` dictionary member is present, and either of |options|' `steal` dictionary member or |options|' `ifAvailable` dictionary member is true, then return [=a promise rejected with=] a "{{NotSupportedError}}" {{DOMException}}.
 1. If |options|' `signal` dictionary member is present and its [=AbortSignal/aborted flag=] is set, then return [=a promise rejected with=] an "{{AbortError}}" {{DOMException}.
 1. Let |promise| be [=a new promise=].
-1. Let |request| be the result of running the steps to [=request a lock=] with |promise|, the current [=/agent=], |environment|'s [=environment/id=], |origin|, |callback|, |name|, |options|' `mode` dictionary member, |options|' `ifAvailable` dictionary member, and |options|' `steal` dictionary member.
-1. If |options|' `signal` dictionary member is present, then <a for=AbortSignal lt=add>add the following abort steps</a> to |options|' `signal` dictionary member:
-    1. [=enqueue the following steps|Enqueue the steps=] to [=abort the request=] |request| to the [=lock task queue=].
-    1. [=Reject=] |promise| with an "{{AbortError}}" {{DOMException}}.
+1. [=Request a lock=] with |promise|, the current [=/agent=], |environment|'s [=environment/id=], |origin|, |callback|, |name|, |options|' `mode` dictionary member, |options|' `ifAvailable` dictionary member, |options|' `steal` dictionary member, and |options|' `signal` dictionary member.
 1. Return |promise|.
 
 </div>
@@ -581,9 +578,10 @@ The <dfn attribute for=Lock>mode</dfn> getter's steps are to return the associat
 <!-- ====================================================================== -->
 
 <div algorithm>
-To <dfn>request a lock</dfn> with |promise|, |agent|, |clientId|, |origin|, |callback|, |name|, |mode|, |ifAvailable| and |steal|:
+To <dfn>request a lock</dfn> with |promise|, |agent|, |clientId|, |origin|, |callback|, |name|, |mode|, |ifAvailable|, |steal|, and |signal|:
 
-1. Let |request| be a new [=lock request=] (|agent|, |clientId|, |origin|, |name|, |mode|, |callback|, |promise|).
+1. Let |request| be a new [=lock request=] (|agent|, |clientId|, |origin|, |name|, |mode|, |callback|, |promise|, |signal|).
+1. If |signal| is present, then <a for=AbortSignal>add</a> the algorithm [=signal to abort the request=] |request| to |signal|.
 1. [=Enqueue the following steps=] to the [=lock task queue=]:
     1. Let |queueMap| be |origin|'s [=lock request queue map=].
     1. Let |queue| be the result of [=/getting the lock request queue=] from |queueMap| for |name|.
@@ -639,6 +637,14 @@ To <dfn>abort the request</dfn> |request|:
 
 </div>
 
+<div algorithm>
+To <dfn>signal to abort the request</dfn> |request|:
+
+1. [=enqueue the following steps|Enqueue the steps=] to [=abort the request=] |request| to the [=lock task queue=].
+1. [=Reject=] |request|'s [=lock request/promise=] with an "{{AbortError}}" {{DOMException}}.
+
+</div>
+
 <!-- ====================================================================== -->
 ## Process a lock request queue for a given resource name ## {#algorithm-process-request}
 <!-- ====================================================================== -->
@@ -656,10 +662,12 @@ To <dfn>process the lock request queue</dfn> |queue|:
         1. Let |mode| be |request|'s [=lock request/mode=].
         1. Let |callback| be |request|'s [=lock request/callback=].
         1. Let |p| be |request|'s [=lock request/promise=].
+        1. Let |signal| be |request|'s [=lock request/signal=].
         1. Let |waiting| be [=a new promise=].
         1. Let |lock| be a new [=lock-concept|lock=] with [=lock-concept/agent=] |agent|, [=lock-concept/clientId=] |clientId|, [=lock-concept/origin=] |origin|, [=lock-concept/mode=] |mode|, [=lock-concept/name=] |name|, [=lock-concept/released promise=] |p|, and [=lock-concept/waiting promise=] |waiting|.
         1. [=set/Append=] |lock| to |origin|'s [=held lock set=].
         1. [=Enqueue the following steps=] on |callback|'s [=relevant settings object=]'s [=responsible event loop=]:
+            1. If |signal| is present, then <a for=AbortSignal>remove</a> the algorithm [=signal to abort the request=] |request| from |signal|.
             1. Let |r| be the result of [=invoking=] |callback| with a new {{Lock}} object associated with |lock| as the only argument.
             1. [=/Resolve=] |waiting| with |r|.
 

--- a/index.bs
+++ b/index.bs
@@ -668,8 +668,10 @@ To <dfn>process the lock request queue</dfn> |queue|:
         1. [=set/Append=] |lock| to |origin|'s [=held lock set=].
         1. [=Enqueue the following steps=] on |callback|'s [=relevant settings object=]'s [=responsible event loop=]:
             1. If |signal| is present, then run these steps:
-                1. If |signal|'s [=AbortSignal/aborted flag=] is set, then [=enqueue the following step=] to the [=lock task queue=]:
-                    1. [=Release the lock=] |lock|.
+                1. If |signal|'s [=AbortSignal/aborted flag=] is set, then run these steps:
+                    1. [=Enqueue the following step=] to the [=lock task queue=]:
+                        1. [=Release the lock=] |lock|.
+                    1. Return.
                 1. [=AbortSignal/Remove=] the algorithm [=signal to abort the request=] |request| from |signal|.
             1. Let |r| be the result of [=invoking=] |callback| with a new {{Lock}} object associated with |lock| as the only argument.
             1. [=/Resolve=] |waiting| with |r|.

--- a/index.bs
+++ b/index.bs
@@ -581,7 +581,7 @@ The <dfn attribute for=Lock>mode</dfn> getter's steps are to return the associat
 To <dfn>request a lock</dfn> with |promise|, |agent|, |clientId|, |origin|, |callback|, |name|, |mode|, |ifAvailable|, |steal|, and |signal|:
 
 1. Let |request| be a new [=lock request=] (|agent|, |clientId|, |origin|, |name|, |mode|, |callback|, |promise|, |signal|).
-1. If |signal| is present, then <a for=AbortSignal>add</a> the algorithm [=signal to abort the request=] |request| to |signal|.
+1. If |signal| is present, then [=AbortSignal/add=] the algorithm [=signal to abort the request=] |request| to |signal|.
 1. [=Enqueue the following steps=] to the [=lock task queue=]:
     1. Let |queueMap| be |origin|'s [=lock request queue map=].
     1. Let |queue| be the result of [=/getting the lock request queue=] from |queueMap| for |name|.
@@ -667,7 +667,9 @@ To <dfn>process the lock request queue</dfn> |queue|:
         1. Let |lock| be a new [=lock-concept|lock=] with [=lock-concept/agent=] |agent|, [=lock-concept/clientId=] |clientId|, [=lock-concept/origin=] |origin|, [=lock-concept/mode=] |mode|, [=lock-concept/name=] |name|, [=lock-concept/released promise=] |p|, and [=lock-concept/waiting promise=] |waiting|.
         1. [=set/Append=] |lock| to |origin|'s [=held lock set=].
         1. [=Enqueue the following steps=] on |callback|'s [=relevant settings object=]'s [=responsible event loop=]:
-            1. If |signal| is present, then <a for=AbortSignal>remove</a> the algorithm [=signal to abort the request=] |request| from |signal|.
+            1. If |signal| is present, then run these steps:
+                1. If |signal|'s [=AbortSignal/aborted flag=] is set, then return.
+                1. [=AbortSignal/Remove=] the algorithm [=signal to abort the request=] |request| from |signal|.
             1. Let |r| be the result of [=invoking=] |callback| with a new {{Lock}} object associated with |lock| as the only argument.
             1. [=/Resolve=] |waiting| with |r|.
 


### PR DESCRIPTION
Closes #79 

I tried describing https://github.com/WICG/web-locks/issues/79#issuecomment-942572758, which matches the currently proposed Gecko implementation.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/web-locks/pull/80.html" title="Last updated on Nov 1, 2021, 9:17 PM UTC (0797b65)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-locks/80/b3e696f...saschanaz:0797b65.html" title="Last updated on Nov 1, 2021, 9:17 PM UTC (0797b65)">Diff</a>