### PR TITLE
Early return when a request is not grantable

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -648,20 +648,20 @@ To <dfn>process the lock request queue</dfn> |queue|:
 
 1. [=Assert=]: these steps are running on the [=lock task queue=].
 1. [=list/For each=] |request| of |queue|:
-    1. If |request| is [=grantable=], then run these steps:
-        1. [=list/Remove=] |request| from |queue|.
-        1. Let |agent| be |request|'s [=lock-concept/agent=]
-        1. Let |clientId| be |request|'s [=lock request/clientId=].
-        1. Let |name| be |request|'s [=lock request/name=].
-        1. Let |mode| be |request|'s [=lock request/mode=].
-        1. Let |callback| be |request|'s [=lock request/callback=].
-        1. Let |p| be |request|'s [=lock request/promise=].
-        1. Let |waiting| be [=a new promise=].
-        1. Let |lock| be a new [=lock-concept|lock=] with [=lock-concept/agent=] |agent|, [=lock-concept/clientId=] |clientId|, [=lock-concept/origin=] |origin|, [=lock-concept/mode=] |mode|, [=lock-concept/name=] |name|, [=lock-concept/released promise=] |p|, and [=lock-concept/waiting promise=] |waiting|.
-        1. [=set/Append=] |lock| to |origin|'s [=held lock set=].
-        1. [=Enqueue the following steps=] on |callback|'s [=relevant settings object=]'s [=responsible event loop=]:
-            1. Let |r| be the result of [=invoking=] |callback| with a new {{Lock}} object associated with |lock| as the only argument.
-            1. [=/Resolve=] |waiting| with |r|.
+    1. If |request| is not [=grantable=], then return.
+    1. [=list/Remove=] |request| from |queue|.
+    1. Let |agent| be |request|'s [=lock-concept/agent=]
+    1. Let |clientId| be |request|'s [=lock request/clientId=].
+    1. Let |name| be |request|'s [=lock request/name=].
+    1. Let |mode| be |request|'s [=lock request/mode=].
+    1. Let |callback| be |request|'s [=lock request/callback=].
+    1. Let |p| be |request|'s [=lock request/promise=].
+    1. Let |waiting| be [=a new promise=].
+    1. Let |lock| be a new [=lock-concept|lock=] with [=lock-concept/agent=] |agent|, [=lock-concept/clientId=] |clientId|, [=lock-concept/origin=] |origin|, [=lock-concept/mode=] |mode|, [=lock-concept/name=] |name|, [=lock-concept/released promise=] |p|, and [=lock-concept/waiting promise=] |waiting|.
+    1. [=set/Append=] |lock| to |origin|'s [=held lock set=].
+    1. [=Enqueue the following steps=] on |callback|'s [=relevant settings object=]'s [=responsible event loop=]:
+        1. Let |r| be the result of [=invoking=] |callback| with a new {{Lock}} object associated with |lock| as the only argument.
+        1. [=/Resolve=] |waiting| with |r|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -649,6 +649,9 @@ To <dfn>process the lock request queue</dfn> |queue|:
 1. [=Assert=]: these steps are running on the [=lock task queue=].
 1. [=list/For each=] |request| of |queue|:
     1. If |request| is not [=grantable=], then return.
+
+        Note: Only the first item in a queue is grantable. Therefore, if something is not grantable then all the following items are automatically not grantable.
+
     1. [=list/Remove=] |request| from |queue|.
     1. Let |agent| be |request|'s [=lock-concept/agent=]
     1. Let |clientId| be |request|'s [=lock request/clientId=].


### PR DESCRIPTION
Fixes #82


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/web-locks/pull/83.html" title="Last updated on Oct 18, 2021, 11:54 PM UTC (316afba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-locks/83/22b3662...saschanaz:316afba.html" title="Last updated on Oct 18, 2021, 11:54 PM UTC (316afba)">Diff</a>