### PR TITLE
Throw InvalidStateError when not fully-active

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -496,6 +496,7 @@ The <dfn method for=LockManager>request(|name|, |callback|)</dfn> and
 
 1. If |options| was not passed, then let |options| be a new {{LockOptions}} dictionary with default members.
 1. Let |environment| be [=/this=]'s [=relevant settings object=].
+1. If |environment|'s [=responsible document=] is not [=fully active=], then return [=a promise rejected with=] a "{{InvalidStateError}}" {{DOMException}}.
 1. Let |origin| be |environment|'s [=/origin=].
 1. If |origin| is an [=opaque origin=], then return [=a promise rejected with=] a "{{SecurityError}}" {{DOMException}}.
 1. If |name| starts with U+002D HYPHEN-MINUS (-), then return [=a promise rejected with=] a "{{NotSupportedError}}" {{DOMException}}.
@@ -553,7 +554,9 @@ The <dfn method for=LockManager>request(|name|, |callback|)</dfn> and
 
 The <dfn method for=LockManager>query()</dfn> method steps are:
 
-1. Let |origin| be [=/this=]'s [=relevant settings object=]'s [=/origin=].
+1. Let |environment| be [=/this=]'s [=relevant settings object=].
+1. If |environment|'s [=responsible document=] is not [=fully active=], then return [=a promise rejected with=] a "{{InvalidStateError}}" {{DOMException}}.
+1. Let |origin| be |environment|'s [=/origin=].
 1. If |origin| is an [=opaque origin=], then return [=a promise rejected with=] a "{{SecurityError}}" {{DOMException}}.
 1. Let |promise| be [=a new promise=].
 1. [=enqueue the following steps|Enqueue the steps=] to [=snapshot the lock state=] for |origin| with |promise| to the [=lock task queue=].


### PR DESCRIPTION
Fixes #78 

This follows Web Share behavior where fully-active check happens as early as possible. Didn't cover workers here since:

1. In bfcache case, we simply don't want to enter bfcache when there are active locks or pending requests. A followup can happen in #81.
2. In unloaded iframe case, any existing workers are seemingly also unloaded, so I believe no special treatment needed.

WPT: https://github.com/web-platform-tests/wpt/pull/31509


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/web-locks/pull/85.html" title="Last updated on Nov 4, 2021, 5:16 PM UTC (91132f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-locks/85/9d5643e...saschanaz:91132f9.html" title="Last updated on Nov 4, 2021, 5:16 PM UTC (91132f9)">Diff</a>